### PR TITLE
Browser support

### DIFF
--- a/rollup-itscss/.browserslistrc
+++ b/rollup-itscss/.browserslistrc
@@ -1,11 +1,12 @@
 # desktop
-ie 11
 last 2 Chrome versions
 last 2 Firefox versions
 last 2 Safari versions
 last 2 Edge versions
 last 2 Opera versions
 
-# mobile (Chrome and Firefox are the same on desktop and mobile)
+# mobile
+last 2 ChromeAndroid versions
+last 2 FirefoxAndroid versions
 last 2 iOS versions
 last 2 samsung versions

--- a/rollup-itscss/babel.config.js
+++ b/rollup-itscss/babel.config.js
@@ -3,6 +3,9 @@ module.exports = {
 		['@babel/preset-env', {
 			useBuiltIns: 'usage',
 			corejs: 3,
+			exclude: [
+				'es.promise', // Edge does not pass the Promise test: https://github.com/zloirock/core-js/issues/579#issuecomment-504325213
+			],
 		}],
 	],
 };

--- a/rollup-itscss/babel.config.js
+++ b/rollup-itscss/babel.config.js
@@ -4,7 +4,9 @@ module.exports = {
 			useBuiltIns: 'usage',
 			corejs: 3,
 			exclude: [
-				'es.promise', // Edge does not pass the Promise test: https://github.com/zloirock/core-js/issues/579#issuecomment-504325213
+				// Edge does not pass the Promise test and thus includes
+				// this polyfill: https://github.com/zloirock/core-js/issues/579#issuecomment-504325213
+				'es.promise',
 			],
 		}],
 	],

--- a/rollup-itscss/babel.config.js
+++ b/rollup-itscss/babel.config.js
@@ -1,11 +1,6 @@
-// Export a 'modern/esmodules' config and
-// override this in the rollup.config.js for the legacy build.
 module.exports = {
 	presets: [
 		['@babel/preset-env', {
-			targets: {
-				esmodules: true,
-			},
 			useBuiltIns: 'usage',
 			corejs: 3,
 		}],

--- a/rollup-itscss/babel.config.legacy.js
+++ b/rollup-itscss/babel.config.legacy.js
@@ -26,6 +26,7 @@ module.exports = {
 			preset,
 			{
 				...settings,
+				exclude: [],
 				targets: {
 					browsers,
 				},

--- a/rollup-itscss/babel.config.legacy.js
+++ b/rollup-itscss/babel.config.legacy.js
@@ -1,21 +1,34 @@
-// Export a 'modern/esmodules' config and
-// override this in the rollup.config.js for the legacy build.
+const browserslist = require('browserslist');
 
-// const config = require('./babel.config');
+const config = require('./babel.config');
 
-// delete config.targets;
+const LEGACY_BROWSERS = [
+	'ie 11',
+];
 
-// config.presets[0][0].debug = true;
+const {
+	presets: [
+		[
+			preset,
+			settings,
+		],
+	],
+} = config;
+
+const browsers = [
+	...browserslist(),
+	...LEGACY_BROWSERS,
+];
 
 module.exports = {
 	presets: [
 		[
-			'@babel/preset-env',
+			preset,
 			{
-				// Uses .browserslistrc for targets
-				useBuiltIns: 'usage',
-				corejs: 3,
-				debug: true,
+				...settings,
+				targets: {
+					browsers,
+				},
 			},
 		],
 	],

--- a/rollup-itscss/babel.config.legacy.js
+++ b/rollup-itscss/babel.config.legacy.js
@@ -1,0 +1,22 @@
+// Export a 'modern/esmodules' config and
+// override this in the rollup.config.js for the legacy build.
+
+// const config = require('./babel.config');
+
+// delete config.targets;
+
+// config.presets[0][0].debug = true;
+
+module.exports = {
+	presets: [
+		[
+			'@babel/preset-env',
+			{
+				// Uses .browserslistrc for targets
+				useBuiltIns: 'usage',
+				corejs: 3,
+				debug: true,
+			},
+		],
+	],
+};

--- a/rollup-itscss/package-lock.json
+++ b/rollup-itscss/package-lock.json
@@ -5616,16 +5616,16 @@
       }
     },
     "rollup-plugin-commonjs": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.0.tgz",
-      "integrity": "sha512-B8MoX5GRpj3kW4+YaFO/di2JsZkBxNjVmZ9LWjUoTAjq8N9wc7HObMXPsrvolVV9JXVtYSscflXM14A19dXPNQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.1.tgz",
+      "integrity": "sha512-x0PcCVdEc4J8igv1qe2vttz8JKAKcTs3wfIA3L8xEty3VzxgORLrzZrNWaVMc+pBC4U3aDOb9BnWLAQ8J11vkA==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.6.0",
+        "estree-walker": "^0.6.1",
         "is-reference": "^1.1.2",
         "magic-string": "^0.25.2",
-        "resolve": "^1.10.1",
-        "rollup-pluginutils": "^2.7.0"
+        "resolve": "^1.11.0",
+        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-plugin-node-resolve": {
@@ -5708,12 +5708,12 @@
       "dev": true
     },
     "sass": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.22.0.tgz",
-      "integrity": "sha512-6BEkdLYPP26cKggrMuBjMWpguMFgeayW+35LGnzXqCipm86fUboSVAdRLFKRpk1ClMNzFZums6kKkjgWF00WoA==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.22.1.tgz",
+      "integrity": "sha512-VsWrNdfIzCLbD2TO2bq9tCaUzEE0UUSGtP3r9IhHi8ypAPCb3FOVP99kMRil+ZROEcTnKReZcQP9vk6ArV2eLw==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.0"
+        "chokidar": ">=2.0.0 <4.0.0"
       }
     },
     "semver": {

--- a/rollup-itscss/package.json
+++ b/rollup-itscss/package.json
@@ -31,10 +31,10 @@
     "regenerator-runtime": "0.13.2",
     "rollup": "1.16.2",
     "rollup-plugin-babel": "4.3.3",
-    "rollup-plugin-commonjs": "10.0.0",
+    "rollup-plugin-commonjs": "10.0.1",
     "rollup-plugin-node-resolve": "5.1.0",
     "rollup-plugin-terser": "5.0.0",
-    "sass": "1.22.0",
+    "sass": "1.22.1",
     "stylelint": "10.1.0",
     "stylelint-config-vi": "1.5.0"
   }

--- a/rollup-itscss/rollup.config.js
+++ b/rollup-itscss/rollup.config.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
@@ -35,18 +37,8 @@ export default [
 		plugins: [
 			...DEFAULT_PLUGINS,
 			babel({
-				babelrc: false,
 				exclude: 'node_modules/**',
-				presets: [
-					[
-						'@babel/preset-env',
-						{
-							// Uses .browserslistrc for targets
-							useBuiltIns: 'usage',
-							corejs: 3,
-						},
-					],
-				],
+				configFile: path.resolve(__dirname, 'babel.config.legacy.js'),
 			}),
 		],
 

--- a/rollup-itscss/rollup.config.js
+++ b/rollup-itscss/rollup.config.js
@@ -22,6 +22,7 @@ export default [
 		plugins: [
 			...DEFAULT_PLUGINS,
 			babel({
+				// Uses the default `babel.config.js` file
 				exclude: 'node_modules/**',
 			}),
 		],


### PR DESCRIPTION
- Remove `IE 11` from list of default supported browsers.
- Remove target: `esmodules: true` and just support the latest 2 browser versions, which all support ES Modules.
- Simplify Babel/Rollup setup.