### PR TITLE
Browserslist env

### DIFF
--- a/rollup-itscss/.browserslistrc
+++ b/rollup-itscss/.browserslistrc
@@ -1,11 +1,8 @@
-# desktop
-# We are not using the `esmodules` target due to: https://github.com/babel/babel/issues/8809
 last 2 Chrome versions
 last 2 Firefox versions
 last 2 Safari versions
 last 2 Edge versions
-
-# mobile
-last 2 ChromeAndroid versions
-last 2 FirefoxAndroid versions
 last 2 iOS versions
+
+[legacy]
+ie 11

--- a/rollup-itscss/.browserslistrc
+++ b/rollup-itscss/.browserslistrc
@@ -1,8 +1,8 @@
-last 2 Chrome versions
-last 2 Firefox versions
-last 2 Safari versions
-last 2 Edge versions
-last 2 iOS versions
+last 2 chrome versions
+last 2 firefox versions
+last 2 safari versions
+last 2 edge versions
+last 2 ios versions
 
 [legacy]
 ie 11

--- a/rollup-itscss/babel.config.js
+++ b/rollup-itscss/babel.config.js
@@ -1,7 +1,3 @@
-const LEGACY_BROWSERS = [
-	'ie 11',
-];
-
 module.exports = {
 	env: {
 		modern: {
@@ -23,12 +19,10 @@ module.exports = {
 						'@babel/plugin-transform-async-to-generator',
 						'@babel/plugin-transform-regenerator',
 					],
-					targets: {
-						browsers: LEGACY_BROWSERS,
-					},
 				}],
 			],
 			plugins: [
+				// But convert async functions to promises.
 				'babel-plugin-transform-async-to-promises',
 			],
 		},

--- a/rollup-itscss/rollup.config.js
+++ b/rollup-itscss/rollup.config.js
@@ -13,6 +13,10 @@ const buildTarget = {
 const INPUT_DIR = 'src/scripts';
 const OUTPUT_DIR = 'dist/js';
 
+function setBrowserslistEnv(env = '') {
+	process.env.BROWSERSLIST_ENV = env;
+}
+
 function basePlugins(target = '') {
 	const plugins = [
 		resolve(),
@@ -50,7 +54,7 @@ const moduleConfig = () => ({
 });
 
 const noModuleConfig = () => {
-	process.env.BROWSERSLIST_ENV = buildTarget.LEGACY;
+	setBrowserslistEnv(buildTarget.LEGACY);
 
 	return {
 		input: `${INPUT_DIR}/main-nomodule.mjs`,

--- a/rollup-itscss/rollup.config.js
+++ b/rollup-itscss/rollup.config.js
@@ -13,7 +13,7 @@ const buildTarget = {
 const INPUT_DIR = 'src/scripts';
 const OUTPUT_DIR = 'dist/js';
 
-function basePlugins(legacy = false) {
+function basePlugins(target = '') {
 	const plugins = [
 		resolve(),
 		commonjs(),
@@ -21,7 +21,7 @@ function basePlugins(legacy = false) {
 
 	if (isProduction) {
 		plugins.push(terser({
-			ecma: legacy ? 5 : 8,
+			ecma: target === buildTarget.LEGACY ? 5 : 8,
 		}));
 	}
 
@@ -63,7 +63,7 @@ const noModuleConfig = () => {
 		},
 
 		plugins: [
-			...basePlugins(true),
+			...basePlugins(buildTarget.LEGACY),
 			babel({
 				envName: buildTarget.LEGACY,
 				exclude: 'node_modules/**',


### PR DESCRIPTION
Use browserslist environments for generating builds. No more overruling of browsers in other files.

Closes #12 